### PR TITLE
Fix Subheading being cut off on login and register page

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -12,7 +12,12 @@ namespace CrocoManager
 
         protected override Window CreateWindow(IActivationState? activationState)
         {
-            return new Window(new AppShell());
+            Window window = new Window(new AppShell());
+#if WINDOWS
+            window.MinimumWidth = 400;
+            window.MinimumHeight = 1000;
+#endif
+            return window;
         }
     }
 }


### PR DESCRIPTION
The Subheading on the Auth pages specifically login and register were always cut off due to layout issues. Since there is no need for the window to be super small on desktop, this was solved by setting a minium window size on windows platform. This closes #1 and closes #3