### PR TITLE
Error Message Feeding Plan

### DIFF
--- a/ViewModel/FeedingPlanViewModel.cs
+++ b/ViewModel/FeedingPlanViewModel.cs
@@ -134,6 +134,12 @@ namespace CrocoManager.ViewModel
         {
             if (plan == null) return;
 
+            if(plan.IsActive)
+            {
+                await NotificationService.ShowWarningAsync("Warnung", "Aktive Futterpläne können nicht gelöscht werden. Bitte zuerst einen anderen Plan aktivieren.");
+                return;
+            }
+
             bool confirm = await NotificationService.ShowConfirmationAsync(
                 "Löschen bestätigen",
                 $"Möchten Sie '{plan.Name}' wirklich löschen?",

--- a/ViewModel/LoginViewModel.cs
+++ b/ViewModel/LoginViewModel.cs
@@ -76,9 +76,6 @@ namespace CrocoManager.ViewModel
         [RelayCommand]
         async Task TestConnectionAsync()
         {
-            //bool ok = await SupabaseService.Instance.TestConnectionAsync();
-            ObservationService obsService = ServiceProvider.GetRequiredService<ObservationService>();
-            await obsService.FetchEnvironmentalDataAsync();
             var ok = await AuthService.TestConnectionAsync();
             await NotificationService.ShowInfoAsync("Connection Test", ok ? "Connected" : "Failed");
         }


### PR DESCRIPTION
Prevoiusly the user was able to delete any and all feeding plans. The domain rules drawn up in the concept dont allow this because one plan must be active at all times. This PR implements error handling for when a user tries to delete a plan that is set as active. It resolves #40 