### PR TITLE
Animal List height FeedingPage

### DIFF
--- a/Views/FeedingPage.xaml
+++ b/Views/FeedingPage.xaml
@@ -94,7 +94,7 @@
             <!-- Animals List -->
             <Border Grid.Row="3"
                     Style="{StaticResource SecondaryCard}"
-                    HeightRequest="330"
+                    HeightRequest="{OnIdiom Desktop=370, Phone=300}"
                     Padding="0"
                     Margin="0">
                 <Border.StrokeShape>


### PR DESCRIPTION
Added an onIdiom for mobile and desktop to allow better height sizing for the animal list on the feeding page this resolves #46 